### PR TITLE
Add footer year test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Alex Rao Website
+
+This repository contains a simple static site. A lightweight test suite is included to verify the footer displays the current year.
+
+## Running the tests
+
+Install dependencies with `pip install -r requirements.txt` and then execute `pytest`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+pytest

--- a/tests/test_footer.py
+++ b/tests/test_footer.py
@@ -1,0 +1,17 @@
+import datetime
+from bs4 import BeautifulSoup
+from pathlib import Path
+
+
+def test_footer_contains_current_year():
+    html_path = Path(__file__).resolve().parents[1] / 'index.html'
+    html = html_path.read_text()
+    soup = BeautifulSoup(html, 'html.parser')
+    footer = soup.find('footer')
+    assert footer is not None, 'Footer element not found'
+    script = footer.find('script')
+    if script and 'new Date().getFullYear()' in script.text:
+        script.replace_with(str(datetime.datetime.now().year))
+    footer_text = footer.get_text(separator=' ', strip=True)
+    current_year = str(datetime.datetime.now().year)
+    assert current_year in footer_text


### PR DESCRIPTION
## Summary
- add `pytest` and `beautifulsoup4` dependencies
- provide instructions on running tests
- check that `index.html` footer shows the current year

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f97e49a348325874c4538c2183309