### PR TITLE
Update homepage badge to 'For business inquiries'

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 </head>
 <body>
     <main class="card">
-        <p class="badge">Open to opportunities</p>
+        <p class="badge">For business inquiries</p>
         <h1>Alex Rao</h1>
         <p class="subtitle">Software engineer focused on building reliable, human-centered products across backend systems, automation, and AI-driven workflows.</p>
 


### PR DESCRIPTION
### Motivation
- Update the hero availability badge copy to explicitly invite business inquiries rather than the previous phrasing.

### Description
- Replaced the badge text in `index.html` from "Open to opportunities" to "For business inquiries".

### Testing
- Ran `pytest -q` and all tests passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cedfec562483258089a8bf4e538f9e)