### PR TITLE
Personalize homepage copy to sound more authentic and specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,20 +154,20 @@
     <main class="card">
         <p class="badge">For business inquiries</p>
         <h1>Alex Rao</h1>
-        <p class="subtitle">Software engineer focused on building reliable, human-centered products across backend systems, automation, and AI-driven workflows.</p>
+        <p class="subtitle">I'm Alex, a software engineer who likes turning messy ideas into dependable products—especially in backend systems, automation, and practical AI tooling.</p>
 
         <section class="grid" aria-label="Highlights">
             <article class="panel">
                 <h2>What I build</h2>
-                <p>Production-ready software with clean architecture, testing discipline, and attention to performance.</p>
+                <p>I build end-to-end features that are meant to ship: clean backend services, dependable APIs, and tooling that holds up in real use.</p>
             </article>
             <article class="panel">
                 <h2>How I work</h2>
-                <p>Fast iteration, clear communication, and thoughtful tradeoffs between speed and maintainability.</p>
+                <p>I work in tight feedback loops, write things down clearly, and make tradeoffs on purpose so teams can move fast without creating long-term chaos.</p>
             </article>
             <article class="panel">
                 <h2>Current focus</h2>
-                <p>Applied AI tooling, developer productivity systems, and products that deliver measurable value.</p>
+                <p>Right now I'm focused on AI-assisted developer workflows, internal automation, and products where I can point to clear before-and-after impact.</p>
             </article>
         </section>
 


### PR DESCRIPTION
### Motivation
- Make the homepage copy feel personal and concrete to reflect Alex's actual work and voice instead of vague, AI-style phrasing.

### Description
- Replace the subtitle and the three highlight panel descriptions in `index.html` with first-person, specific lines that describe what Alex builds, how he works, and his current focus.

### Testing
- Ran `pytest -q`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cefa3b12d88325b954faaa9a21aa67)